### PR TITLE
fix: remove SATA license

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -36,11 +36,9 @@ Many materials were referred to during the process of writing this project, we w
 
 [![CC][cc-img]][cc-url]
 
-Apart from special statement, the content (expect the code) of this site was published under [Creative Commons BY-SA 4.0][cc-url] and [The Star And Thank Author License](https://github.com/zTrix/sata-license).
+Apart from special statement, the content (expect the code) of this site was published under [Creative Commons BY-SA 4.0][cc-url].
 
 In a nutshell, you are free to share and adapt, but you must give the appropriate credit and share under the same license without additional restrictions.
-
-And star GitHub repo.
 
 If you would like to cite this GitHub repo, you can use the bibtex below：
 

--- a/README-ES.md
+++ b/README-ES.md
@@ -36,11 +36,9 @@ En la elaboración de este proyecto se han hecho numerosas referencias, que se a
 
 [![CC][cc-img]][cc-url]
 
-Aparte de especial declaración, el contenido (menos el cógido) del sitio es publicado bajo [Reconocimiento-CompartirIgual BY-SA 4.0][cc-url] y [The Star And Thank Author License](https://github.com/zTrix/sata-license).
+Aparte de especial declaración, el contenido (menos el cógido) del sitio es publicado bajo [Reconocimiento-CompartirIgual BY-SA 4.0][cc-url].
 
 Usted es libre de compartir y adaptar, Usted debe dar crédito de manera adecuada y compartir bajo la lamisma licencia sin restricciones adicionales.
-
-Y star el GitHub repo por favor.
 
 Si quieres citar este GitHub repo, puedes usar el bibtex：
 

--- a/README-T.md
+++ b/README-T.md
@@ -35,11 +35,9 @@ MtF Wiki 致力於成為一個免費開放且持續更新的跨性別知識整�
 
 [![創用CC許可協議][cc-img]][cc-url]
 
-除特別註明外，專案中除了程式碼部分均採用 [(Creative Commons BY-SA 4.0) 創用CC 姓名標示-相同方式分享 4.0 國際許可協議][cc-url] 及附加的 [The Star And Thank Author License](https://github.com/zTrix/sata-license) 進行許可。
+除特別註明外，專案中除了程式碼部分均採用 [(Creative Commons BY-SA 4.0) 創用CC 姓名標示-相同方式分享 4.0 國際許可協議][cc-url] 進行許可。
 
 換言之，使用過程中您可以自由地共享、演繹，但是必須署名、以相同方式分享、分享時沒有附加限制，
-
-而且需要為此 GitHub Repo 標星（Star）。
 
 而如果你想要引用這個 GitHub Repo，可以使用如下的 bibtex：
 

--- a/README.md
+++ b/README.md
@@ -36,11 +36,9 @@ MtF Wiki 致力于成为一个免费开放且持续更新的跨性别知识整�
 
 [![知识共享许可协议][cc-img]][cc-url]
 
-除特别注明外，项目中除了代码部分均采用 [(Creative Commons BY-SA 4.0) 知识共享署名 - 相同方式共享 4.0 国际许可协议][cc-url] 及附加的 [The Star And Thank Author License](https://github.com/zTrix/sata-license) 进行许可。
+除特别注明外，项目中除了代码部分均采用 [(Creative Commons BY-SA 4.0) 知识共享署名 - 相同方式共享 4.0 国际许可协议][cc-url] 进行许可。
 
 换言之，使用过程中您可以自由地共享、演绎，但是必须署名、以相同方式共享、分享时没有附加限制，
-
-而且需要为 GitHub 仓库点赞（Star）。
 
 而如果你想要引用这个 GitHub 仓库，可以使用如下的 bibtex：
 


### PR DESCRIPTION
because it is conflict with CC BY-SA 4.0
CC BY-SA don't allow additional restriction (https://creativecommons.org/licenses/by-sa/4.0/)
Need all contributors agree.

- [x] @saeziae 
- [x] @CoelacanthusHex 
- [x] @llh721113 
- [x] @KevinZonda 
- [ ] @kenchiu233 
- [x] @Misaka13514 
- [x] @IndigoMad 
- [ ] @Chiaki2333 
- [ ] @KaguraTart 
- [x] @undefined-moe 
- [x] @Cattttttttt 
- [ ] @Subarupan 
- [ ] @ezrameow 
- [ ] @wychlw 
- [x] @Xeonacid 