### PR TITLE
Add missing links to index pages's content

### DIFF
--- a/content/zh-cn/docs/hrt/_index.md
+++ b/content/zh-cn/docs/hrt/_index.md
@@ -3,3 +3,19 @@ title: HRT 医疗资源
 weight: 3
 collapsible: true
 ---
+
+[北医三院]({{< ref "pku3" >}})
+
+[上海中山医院｜李小英]({{< ref "li-xiaoying" >}})
+
+[上海九院｜程辰]({{< ref "sh9" >}})
+
+[上海新华医院｜邱文娟]({{< ref "qiu-wenjuan" >}})
+
+[四川省人民医院｜王小红]({{< ref "wang-xiaohong" >}})
+
+[广州暨南一院｜高绿芬]({{< ref "jnuh1" >}})
+
+[苏州市立医院｜周建英]({{< ref "zhou-jianying" >}})
+
+[长沙湘雅三院｜龙智]({{< ref "xiangya3" >}})

--- a/content/zh-cn/docs/medicine/_index.md
+++ b/content/zh-cn/docs/medicine/_index.md
@@ -7,3 +7,5 @@ collapsible: true
 [HRT 总述]({{< ref "hrt-overview" >}})
 
 [进行激素检查]({{< ref "hormone-check" >}})
+
+[自购药防诈骗]({{< ref "anti-fraud" >}})

--- a/content/zh-cn/docs/medicine/antiandrogen/_index.md
+++ b/content/zh-cn/docs/medicine/antiandrogen/_index.md
@@ -7,3 +7,5 @@ collapsible: true
 [HRT 总述]({{< ref "hrt-overview" >}})
 
 [进行激素检查]({{< ref "hormone-check" >}})
+
+[自购药防诈骗]({{< ref "anti-fraud" >}})

--- a/content/zh-cn/docs/medicine/estrogen/_index.md
+++ b/content/zh-cn/docs/medicine/estrogen/_index.md
@@ -7,3 +7,5 @@ collapsible: true
 [HRT 总述]({{< ref "hrt-overview" >}})
 
 [进行激素检查]({{< ref "hormone-check" >}})
+
+[自购药防诈骗]({{< ref "anti-fraud" >}})

--- a/content/zh-cn/docs/psyco/ICD11/index.md
+++ b/content/zh-cn/docs/psyco/ICD11/index.md
@@ -2,7 +2,6 @@
 title: 有关ICD-11
 description: 有关ICD11实行以后的信息（2022年1月更新）
 weight: 21
-collapsible: true
 ---
 
 ## 有关icd-11

--- a/content/zh-cn/docs/psyco/_index.md
+++ b/content/zh-cn/docs/psyco/_index.md
@@ -3,3 +3,7 @@ title: 心理科／精神科
 weight: 2
 collapsible: true
 ---
+
+[介绍信]({{< ref "introletter" >}})
+
+[有关ICD-11]({{< ref "icd11" >}})

--- a/content/zh-cn/docs/srs/_index.md
+++ b/content/zh-cn/docs/srs/_index.md
@@ -3,3 +3,15 @@ title: SRS 性别重置手术
 weight: 4
 collapsible: true
 ---
+
+[术前科普]({{< ref "faq" >}})
+
+[手术技术]({{< ref "tech" >}})
+
+[术后护理]({{< ref "care" >}})
+
+[手术评价方法]({{< ref "compraise" >}})
+
+[证件变更指引]({{< ref "id-card" >}})
+
+[学籍学历变更指引]({{< ref "education" >}})


### PR DESCRIPTION
在某个分类下有子分类时，该分类的页面中不会显示非子分类的子项目，但菜单中照常显示。

这对手机端浏览很不友好，因为手机端菜单是折叠的，正文部分缺少一些链接，特别对新用户比较不友好。