### PR TITLE
fix: link of *Gogo变成猫猫了*

### DIFF
--- a/content/zh-cn/docs/srs/thailand/kamol.md
+++ b/content/zh-cn/docs/srs/thailand/kamol.md
@@ -126,4 +126,4 @@ Kamol 提供 0 深度、PI 皮瓣、非 PI 皮瓣、结肠 和 腹膜 SRS．
 
 ## 内容参考
 
-[Gogo 变成猫猫了——SRS 日志](https://blog.gogo.moe/Gogo%E8%AE%8A%E6%88%90%E8%B2%93%E8%B2%93%E4%BA%86/)<!--不要改成汉字以免简繁转换导致404-->
+[Gogo 变成猫猫了——SRS 日志](https://blog.gogo.moe/gogo_became_a_cat/)

--- a/content/zh-hant/docs/srs/thailand/kamol.md
+++ b/content/zh-hant/docs/srs/thailand/kamol.md
@@ -126,4 +126,4 @@ Kamol 提供 0 深度、PI 皮瓣、非 PI 皮瓣、結腸 和 腹膜 SRS．
 
 ## 內容參考
 
-[Gogo 變成貓貓了——SRS 日誌](https://blog.gogo.moe/Gogo%E8%AE%8A%E6%88%90%E8%B2%93%E8%B2%93%E4%BA%86/)<!--不要改成漢字以免簡繁轉換導致404-->
+[Gogo 變成貓貓了——SRS 日誌](https://blog.gogo.moe/gogo_became_a_cat/)


### PR DESCRIPTION
Hi wiki team, I'm Gogo, the author of [Gogo变成猫猫了](https://blog.gogo.moe/gogo_became_a_cat/).
I found that the link to my blog is broken due to the traditional/simple conversion and a mistaken edit.

I migrated the url from [https://blog.gogo.moe/Gogo变成猫猫了/](https://blog.gogo.moe/Gogo变成猫猫了/) to [https://blog.gogo.moe/gogo_became_a_cat/](https://blog.gogo.moe/gogo_became_a_cat/) to avoid the common mistaken appear again, and added two alias [Gogo变成猫猫了](https://blog.gogo.moe/Gogo变成猫猫了/) and [Gogo變成貓貓了](https://blog.gogo.moe/Gogo變成貓貓了/) 