### PR TITLE
暂时撤下美国改证指引

### DIFF
--- a/content/zh-cn/docs/useful-info/document-updates/unitedstates.md
+++ b/content/zh-cn/docs/useful-info/document-updates/unitedstates.md
@@ -1,6 +1,7 @@
 ---
 title: 美国
 weight: 10001
+draft: true
 ---
 
 ## 联邦文件修改


### PR DESCRIPTION
鉴于目前美国联邦政府相关政策，事情明朗前宜撤下相关内容