### PR TITLE
fix: mdx parsing error

### DIFF
--- a/content/zh-cn/docs/hrt/espana.md
+++ b/content/zh-cn/docs/hrt/espana.md
@@ -27,7 +27,7 @@ weight: 10724
 
 雌激素：
 
-- 口服[戊酸雌二醇]({{< ref estradiol-valerate >}}
+- 口服[戊酸雌二醇]({{< ref estradiol-valerate >}})
 - 贴片（Evopad STT®）
 - 喷雾（Lenzetto®）
 


### PR DESCRIPTION
before
<img width="975" height="1227" alt="image" src="https://github.com/user-attachments/assets/b92fbf44-e0f3-4e36-b27f-48e60f3a67d1" />
after
<img width="943" height="1092" alt="image" src="https://github.com/user-attachments/assets/4edf8569-ca24-4583-8469-4a17813c0a97" />
