### PR TITLE
fix(#1579): 修正security.txt文件路径问题

### DIFF
--- a/static/.well-known/security.txt
+++ b/static/.well-known/security.txt
@@ -1,3 +1,0 @@
-Contact: mailto:security@mtf.wiki
-Preferred-Languages: zh, en
-Canonical: https://mtf.wiki/.well-known/security.txt


### PR DESCRIPTION
目前站点的`security.txt`文件位于 https://mtf.wiki/hugo-static/.well-known/security.txt

但根据 RFC 9116 规范，`security.txt`只能放置在网站根目录下的`/.well-known/`路径。

这个PR会删除当前路径下的文件。然后再将文件移动至[Next-MtF-wiki](https://github.com/project-trans/Next-MtF-wiki)仓库的`public`目录。