### PR TITLE
update:高绿芬医生就诊细节及开药信息

### DIFF
--- a/content/zh-cn/docs/hrt/jnuh1/index.md
+++ b/content/zh-cn/docs/hrt/jnuh1/index.md
@@ -5,6 +5,12 @@ weight: 300
 
 {{< doctor-image src="doctor.jpg" >}}
 
+{{< notice success 巡回 >}}
+
+这个条目曾经被条目人物巡回过。终于{{< mtf-wiki>}}也到了足够让公式前来巡回的知名度了吗！？
+
+{{< /notice >}}
+
 医生姓名：[高绿芬](https://h.jd120.com/Reserve/Doctor/21056)
 
 所在医院：[暨南大学附属第一医院（广州华侨医院）](https://amap.com/place/B00140US6O)


### PR DESCRIPTION
最新消息：最近开始高绿芬医生开出的青春期阻断药物将无法使用任何医保报销
其次高绿芬医生组织的跨性别小组已经结束